### PR TITLE
Added default quality and format option, Added input field and featur…

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -49,27 +49,10 @@ async function shouldShowContextMenu() {
     return 'showContextMenu' in item ? item.showContextMenu : true;
 }
 
-
-async function getReplaceWithYoutube() {
-    let item = await browser.storage.sync.get("replaceWithYoutube");
-    return item.replaceWithYoutube;
-}
-
 async function sendToMeTube(itemUrl, quality, format) {
     itemUrl = itemUrl || await getCurrentUrl();
     console.log(`Send to MeTube. Url: ${itemUrl}, quality: ${quality}, format: ${format}`);
     let meTubeUrl = await getMeTubeUrl();
-    let replaceWithYoutube = await getReplaceWithYoutube();
-    if(replaceWithYoutube && itemUrl){
-        replaceWithYoutube = replaceWithYoutube.split(',');
-        for (let i = 0; i < replaceWithYoutube.length; i++) {
-            let item = replaceWithYoutube[i].trim();
-            if(item.indexOf("youtube.com") === -1 && itemUrl.indexOf(item) !== -1){
-                itemUrl = itemUrl.replace(item, "www.youtube.com");
-                break;
-            }
-        } 
-    }
     if (!meTubeUrl) {
         await showError('MeTube instance url not configured. Go to about:addons to configure.');
     }

--- a/src/background.js
+++ b/src/background.js
@@ -49,11 +49,27 @@ async function shouldShowContextMenu() {
     return 'showContextMenu' in item ? item.showContextMenu : true;
 }
 
+
+async function getReplaceWithYoutube() {
+    let item = await browser.storage.sync.get("replaceWithYoutube");
+    return item.replaceWithYoutube;
+}
+
 async function sendToMeTube(itemUrl, quality, format) {
     itemUrl = itemUrl || await getCurrentUrl();
     console.log(`Send to MeTube. Url: ${itemUrl}, quality: ${quality}, format: ${format}`);
     let meTubeUrl = await getMeTubeUrl();
-
+    let replaceWithYoutube = await getReplaceWithYoutube();
+    if(replaceWithYoutube && itemUrl){
+        replaceWithYoutube = replaceWithYoutube.split(',');
+        for (let i = 0; i < replaceWithYoutube.length; i++) {
+            let item = replaceWithYoutube[i].trim();
+            if(item.indexOf("youtube.com") === -1 && itemUrl.indexOf(item) !== -1){
+                itemUrl = itemUrl.replace(item, "www.youtube.com");
+                break;
+            }
+        } 
+    }
     if (!meTubeUrl) {
         await showError('MeTube instance url not configured. Go to about:addons to configure.');
     }

--- a/src/options.html
+++ b/src/options.html
@@ -14,10 +14,6 @@
           <input type="text" id="url" placeholder="https://meetube.example.com">
         </div>
         <div>
-          <label for="replaceWithYoutube">Url to replace with www.youtube.com (comma seprated)</label><br>
-          <input type="text" id="replaceWithYoutube" placeholder="invidious.snopyta.org,invidious.kavin.rocks">
-        </div>
-        <div>
           <label for="defaultQuality">Default quality:</label>
           <select name="defaultQuality" id="defaultQuality">
               <option value="best">Best</option>

--- a/src/options.html
+++ b/src/options.html
@@ -14,6 +14,29 @@
           <input type="text" id="url" placeholder="https://meetube.example.com">
         </div>
         <div>
+          <label for="replaceWithYoutube">Url to replace with www.youtube.com (comma seprated)</label><br>
+          <input type="text" id="replaceWithYoutube" placeholder="invidious.snopyta.org,invidious.kavin.rocks">
+        </div>
+        <div>
+          <label for="defaultQuality">Default quality:</label>
+          <select name="defaultQuality" id="defaultQuality">
+              <option value="best">Best</option>
+              <option value="1440">1440p</option>
+              <option value="1080">1080p</option>
+              <option value="720">720p</option>
+              <option value="480">480p</option>
+              <option value="audio">Audio only</option>
+          </select>
+        </div>
+        <div>
+          <label for="defaultFormat">Default format:</label>
+          <select name="defaultFormat" id="defaultFormat">
+              <option value="any">Any</option>
+              <option value="mp4">MP4</option>
+              <option value="mp3">MP3</option>
+          </select>
+        </div>
+        <div>
           <input type="checkbox" id="openInNewTab" />
           <label for="openInNewTab">Open MeTube instance in new tab after adding to queue</label>
         </div>

--- a/src/options.js
+++ b/src/options.js
@@ -5,6 +5,9 @@ function saveOptions(e) {
   
   browser.storage.sync.set({
     url: document.querySelector("#url").value,
+    replaceWithYoutube: document.querySelector("#replaceWithYoutube").value,
+    defaultQuality: document.querySelector("#defaultQuality").value,
+    defaultFormat: document.querySelector("#defaultFormat").value,
     openInNewTab: document.querySelector("#openInNewTab").checked,
     showContextMenu,
   });
@@ -22,6 +25,21 @@ function restoreOptions() {
   let getUrl = browser.storage.sync.get("url");
   getUrl.then(function(result) {
     document.querySelector("#url").value = result.url || "";
+  }, onError);
+
+  let getReplaceWithYoutube = browser.storage.sync.get("replaceWithYoutube");
+  getReplaceWithYoutube.then(function(result) {
+    document.querySelector("#replaceWithYoutube").value = result.replaceWithYoutube || "";
+  }, onError);
+
+  let getDefaultQuality = browser.storage.sync.get("defaultQuality");
+  getDefaultQuality.then(function(result) {
+    document.querySelector("#defaultQuality").value = result.defaultQuality || "best";
+  }, onError);
+
+  let getDefaultFormat = browser.storage.sync.get("defaultFormat");
+  getDefaultFormat.then(function(result) {
+    document.querySelector("#defaultFormat").value = result.defaultFormat || "any";
   }, onError);
 
   let getOpenInNewTab = browser.storage.sync.get("openInNewTab");

--- a/src/options.js
+++ b/src/options.js
@@ -5,7 +5,6 @@ function saveOptions(e) {
   
   browser.storage.sync.set({
     url: document.querySelector("#url").value,
-    replaceWithYoutube: document.querySelector("#replaceWithYoutube").value,
     defaultQuality: document.querySelector("#defaultQuality").value,
     defaultFormat: document.querySelector("#defaultFormat").value,
     openInNewTab: document.querySelector("#openInNewTab").checked,
@@ -25,11 +24,6 @@ function restoreOptions() {
   let getUrl = browser.storage.sync.get("url");
   getUrl.then(function(result) {
     document.querySelector("#url").value = result.url || "";
-  }, onError);
-
-  let getReplaceWithYoutube = browser.storage.sync.get("replaceWithYoutube");
-  getReplaceWithYoutube.then(function(result) {
-    document.querySelector("#replaceWithYoutube").value = result.replaceWithYoutube || "";
   }, onError);
 
   let getDefaultQuality = browser.storage.sync.get("defaultQuality");

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -42,7 +42,7 @@ select {
 #buttons-row {
     display: flex;
     justify-content: flex-end;
-    margin-top: 1.5rem;
+    margin-top: .5rem;
 }
 
 #buttons-row button {
@@ -82,4 +82,15 @@ select {
 
 #buttons-row button:active {
     opacity: .5;
+}
+
+#urlInput{  
+    width: 100%;
+    padding: 4px 8px;
+    font-size: 12px;
+    box-sizing: border-box;
+    border: 1px solid #eee;
+    border-radius: .25em;
+    background-color: #fff; 
+    margin-top: 1rem;
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -28,6 +28,9 @@
             </select>
         </div>
     </div>
+    <div id="url-input-container" class="url-input">
+        <input id="urlInput" type="text" placeholder="URL">
+    </div>
     <div id="buttons-row">
         <button id="sendToMeTube" class="send-to-metube">Send to MeTube</button>
     </div>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -36,11 +36,6 @@ async function getCurrentUrl() {
     return tabs[0].url;
 }
 
-async function getReplaceWithYoutube() {
-    let item = await browser.storage.sync.get("replaceWithYoutube");
-    return item.replaceWithYoutube;
-}
-
 async function getDefaultFormat() {
     let item = await browser.storage.sync.get("defaultFormat");
     return item.defaultFormat;
@@ -53,20 +48,9 @@ async function getDefaultQuality() {
 
 addEventListener('DOMContentLoaded', async (event) => {
     let url = await getCurrentUrl();
-    let replaceWithYoutube = await getReplaceWithYoutube();
     let defaultFormat = await getDefaultFormat();
     let defaultQuality = await getDefaultQuality();
-    if(url.indexOf("://") === -1) url = "";
-    if(replaceWithYoutube && url){
-        replaceWithYoutube = replaceWithYoutube.split(',');
-        for (let i = 0; i < replaceWithYoutube.length; i++) {
-            let item = replaceWithYoutube[i].trim();
-            if(item.indexOf("youtube.com") === -1 && url.indexOf(item) !== -1){
-                url = url.replace(item, "www.youtube.com");
-                break;
-            }
-        } 
-    }
+    if(url && url.indexOf("://") === -1) url = "";
     document.getElementById('urlInput').value = url || "";
     document.getElementById('format').value = defaultFormat || "any";
     document.getElementById('quality').value = defaultQuality || "best";

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,7 +1,8 @@
 document.getElementById("sendToMeTube").addEventListener("click", async function () {
     let quality = document.getElementById('quality').value;
     let format = document.getElementById('format').value;
-    await browser.runtime.sendMessage({command: 'sendToMeTube', quality: quality, format: format});
+    let url = document.getElementById('urlInput').value;
+    await browser.runtime.sendMessage({command: 'sendToMeTube', quality: quality, format: format, url: url});
 });
 
 function showError(errorMessage) {
@@ -27,4 +28,46 @@ browser.runtime.onMessage.addListener(async (message) => {
             window.close();
         }, 1500);
     }
+});
+
+
+async function getCurrentUrl() {
+    let tabs = await browser.tabs.query({currentWindow: true, active: true});
+    return tabs[0].url;
+}
+
+async function getReplaceWithYoutube() {
+    let item = await browser.storage.sync.get("replaceWithYoutube");
+    return item.replaceWithYoutube;
+}
+
+async function getDefaultFormat() {
+    let item = await browser.storage.sync.get("defaultFormat");
+    return item.defaultFormat;
+}
+
+async function getDefaultQuality() {
+    let item = await browser.storage.sync.get("defaultQuality");
+    return item.defaultQuality;
+}
+
+addEventListener('DOMContentLoaded', async (event) => {
+    let url = await getCurrentUrl();
+    let replaceWithYoutube = await getReplaceWithYoutube();
+    let defaultFormat = await getDefaultFormat();
+    let defaultQuality = await getDefaultQuality();
+    if(url.indexOf("://") === -1) url = "";
+    if(replaceWithYoutube && url){
+        replaceWithYoutube = replaceWithYoutube.split(',');
+        for (let i = 0; i < replaceWithYoutube.length; i++) {
+            let item = replaceWithYoutube[i].trim();
+            if(item.indexOf("youtube.com") === -1 && url.indexOf(item) !== -1){
+                url = url.replace(item, "www.youtube.com");
+                break;
+            }
+        } 
+    }
+    document.getElementById('urlInput').value = url || "";
+    document.getElementById('format').value = defaultFormat || "any";
+    document.getElementById('quality').value = defaultQuality || "best";
 });


### PR DESCRIPTION
Hi,
I recently setup a metube instance and really appreciate this firefox extension. While using this extension, I thought of a few things that would enhance my experience, so took a couple of hours and added them. I created this PR thinking these features could improve the overall experience of the extension. Feel free to do any changes according to your liking, you can also cancel this PR if you feel the features are not applicable or incorrectly implemented. Changes done in this PR:

1. Added default values to the settings menu, every time the popup loads the saved values of quality and format is fetched and rendered. 
2. Added an input field to popup, borrowed this idea from the extension of [YoutubeDL-Material](https://github.com/Tzahi12345/YoutubeDL-Material). I saw the code for url in message content in background.js so figured to use it, its helpful for editing the url before submitting. 
3. My metube setup uses "SponsorBlock" and I like to use invidious to browse youtube, I am not sure if an invidious link works with some yt-dlp features so I added an option to replace invidious urls configured in settings menu with "www.youtube.com". The implementation is not the cleanest and could use a dynamic form of key value pair of string to replace and string to replace with, instead of comma separated strings to replace with youtube.com but this was easier to implement and seems to do the job. 
