### PR TITLE
Add ability to configure custom headers

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -59,6 +59,15 @@ async function getDefaultFormat() {
     return item.defaultFormat ?? 'any';
 }
 
+async function shouldSendCustomHeaders() {
+    let item = await browser.storage.sync.get("sendCustomHeaders");
+    return item.sendCustomHeaders ?? false;
+}
+
+async function customHeaders() {
+    let item = await browser.storage.sync.get("customHeaders");
+    return item.customHeaders ?? [];
+}
 
 async function sendToMeTube(itemUrl, quality, format) {
     itemUrl = itemUrl || await getCurrentUrl();
@@ -71,6 +80,15 @@ async function sendToMeTube(itemUrl, quality, format) {
     let url = new URL("add", meTubeUrl);
     let xhr = new XMLHttpRequest();
     xhr.open("POST", url.toString());
+
+    const useCustomHeaders = await shouldSendCustomHeaders();
+    if (useCustomHeaders) {
+        const headers = await customHeaders();
+        headers.forEach(header => {
+            xhr.setRequestHeader(header.name, header.value);
+        });
+    }
+    
     xhr.send(JSON.stringify({"url": itemUrl, "quality": quality, "format": format}));
     xhr.onload = async function () {
         if (xhr.status === 200) {

--- a/src/options.css
+++ b/src/options.css
@@ -1,0 +1,39 @@
+.hidden {
+    display: none;
+}
+
+.section {
+    border: 1px solid #ccc;
+    padding: 0 1rem;
+    margin-bottom: 1rem;
+}
+
+.inline-form-fields {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.5rem;
+}
+
+.inline-form-fields input {
+    display: block;
+}
+
+.list-unstyled {
+    list-style: none;
+    padding: 0;
+}
+
+.header-pair {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.header-pair code {
+    border: 1px solid #ccc;
+    background-color: #eee;
+    padding: 0.25rem;
+}
+
+.text-danger {
+    color: tomato;
+}

--- a/src/options.html
+++ b/src/options.html
@@ -3,6 +3,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <link rel="stylesheet" href="options.css" />
   </head>
 
   <body>
@@ -40,6 +41,27 @@
           <input type="checkbox" id="showContextMenu" />
           <label for="showContextMenu">Show context menu in supported sites.</label>
         </div>
+        <div>
+          <input type="checkbox" id="sendCustomHeaders" />
+          <label for="sendCustomHeaders">Send custom headers.</label>
+        </div>
+        <section id="customHeadersSection" class="section hidden">
+          <p>Custom headers which are included when queueing to MeTube instance.</p>
+          <p>These can be used to provide credentials if your MeTube instance is behind a proxy or auth service.</p>
+          <div class="inline-form-fields">
+            <div>
+              <label for="headerNameInput">Header name:</label>
+              <input type="text" id="headerNameInput" placeholder="X-Foo-Header" />
+            </div>
+            <div>
+              <label for="headerValueInput">Header value:</label>
+              <input type="text" id="headerValueInput" placeholder="some-custom-value" />
+            </div>             
+             <button type="button" id="addHeaderButton" aria-label="Add custom header">➕</button>
+          </div>
+          <div id="headerValidationMessage" class="text-danger"></div>
+          <ul id="headersList" class="list-unstyled"></ul>
+        </section>
         <button type="submit">Save</button>
       </fieldset>
     </form>

--- a/src/options.js
+++ b/src/options.js
@@ -9,6 +9,8 @@ function saveOptions(e) {
     defaultFormat: document.querySelector("#defaultFormat").value,
     openInNewTab: document.querySelector("#openInNewTab").checked,
     showContextMenu,
+    sendCustomHeaders: document.querySelector("#sendCustomHeaders").checked,
+    customHeaders: Array.from(document.querySelectorAll('.header-pair')).map(el => ({ name: el.dataset.name, value: el.dataset.value })),
   });
   
   browser.menus.update("send-to-metube", {
@@ -45,8 +47,83 @@ function restoreOptions() {
   showContextMenu.then(function(result) {
     document.querySelector("#showContextMenu").checked = result.showContextMenu || false;
   }, onError);
+
+  let sendCustomHeaders = browser.storage.sync.get("sendCustomHeaders");
+  sendCustomHeaders.then(function(result) {
+    document.querySelector("#sendCustomHeaders").checked = result.sendCustomHeaders;
+    result.sendCustomHeaders ? showCustomHeadersSection() : hideCustomHeadersSection();
+  });
+
+  let customHeaders = browser.storage.sync.get("customHeaders");
+  customHeaders.then(function(result) {  
+    result.customHeaders?.forEach(header => addCustomHeader(header));
+  }, onError);
 }
 
+function showCustomHeadersSection() {
+  document.getElementById("customHeadersSection")?.classList.remove("hidden");
+}
+
+function hideCustomHeadersSection() {
+  document.getElementById("customHeadersSection")?.classList.add("hidden");
+}
+
+function setupCustomHeadersSection() {
+  const headerNameInput = document.getElementById("headerNameInput");
+  const headerValueInput = document.getElementById("headerValueInput");
+  const addHeaderButton = document.getElementById("addHeaderButton");
+  const headerValidationMessageEl = document.getElementById("headerValidationMessage");
+
+  document.getElementById("sendCustomHeaders").addEventListener("change", (event) => {
+    event.target.checked ? showCustomHeadersSection() : hideCustomHeadersSection();
+  });
+
+  addHeaderButton.addEventListener("click", () => {
+    const name = headerNameInput.value;
+    const value = headerValueInput.value;
+
+    let validationError = '';
+    if (!name || !value) {
+      validationError = 'Enter a header name and value';
+    }
+
+    headerValidationMessageEl.innerText = validationError;
+    if (validationError) {
+      return;
+    }
+
+    addCustomHeader({ name, value });
+
+    headerNameInput.value = '';
+    headerValueInput.value = '';
+  });
+}
+
+function removeCustomHeader(header) {
+  headersList.querySelector(`[data-name="${header.name}"]`)?.remove();
+}
+
+function addCustomHeader(header) {
+  const headersList = document.getElementById('headersList');
+
+  const listItem = document.createElement('li');
+  listItem.classList.add('header-pair');
+  listItem.dataset.name = header.name;
+  listItem.dataset.value = header.value;
+  listItem.innerHTML = `
+    <code>${header.name}</code><code>${header.value}</code>
+  `;
+
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.setAttribute('aria-label', 'Remove custom header');
+  removeBtn.innerText = '➖';
+  removeBtn.addEventListener('click', () => removeCustomHeader(header));
+  listItem.appendChild(removeBtn);
+
+  headersList.appendChild(listItem);
+}
+
+document.addEventListener("DOMContentLoaded", setupCustomHeadersSection);
 document.addEventListener("DOMContentLoaded", restoreOptions);
 document.querySelector("form").addEventListener("submit", saveOptions);
-


### PR DESCRIPTION
Adds the ability to configure custom headers within the extension options. These headers are then applied to the request made when queuing items to MeTube.

This is useful if your MeTube instance is deployed behind a reverse proxy or other auth provider. Should fix #6

![image](https://github.com/nanocortex/metube-firefox-addon/assets/630652/1cb12d01-7b6e-40bb-8221-770bba22e6e9)

Note header values are stored using `browser.storage.sync` as per existing extension options, and are not encrypted or handled as secrets in any way.
