### PR TITLE
Add Strict Playlist Mode setting

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -24,7 +24,7 @@ browser.browserAction.onClicked.addListener(async () => {
     const url = await getCurrentUrl();
     const options = await getDefaultSendOptions();
     await sendToMeTube(url, options.quality, options.format, options.folder,
-                       options.customNamePrefix, options.autoStart);
+                       options.customNamePrefix, options.autoStart, options.strictPlaylistMode);
   }
 });
 
@@ -103,11 +103,12 @@ async function getDefaultSendOptions() {
     format: await getDefaultFormat(),
     folder: await getDefaultFolder(),
     customNamePrefix: await getDefaultCustomNamePrefix(),
-    autoStart: await getDefaultAutoStart()
+    autoStart: await getDefaultAutoStart(),
+    strictPlaylistMode: await getDefaultStrictPlaylistMode()
   };
 }
 
-async function sendToMeTube(itemUrl, quality, format, folder, customNamePrefix, autoStart) {
+async function sendToMeTube(itemUrl, quality, format, folder, customNamePrefix, autoStart, strictPlaylistMode) {
   if (isRequestInProgress) {
     console.log("Request already in progress, ignoring duplicate request");
     return;
@@ -117,7 +118,7 @@ async function sendToMeTube(itemUrl, quality, format, folder, customNamePrefix, 
 
   try {
     itemUrl = itemUrl || await getCurrentUrl();
-    console.log(`Send to MeTube. Url: ${itemUrl}, quality: ${quality}, format: ${format}, folder: ${folder}, customNamePrefix: ${customNamePrefix}, autoStart: ${autoStart}`);
+    console.log(`Send to MeTube. Url: ${itemUrl}, quality: ${quality}, format: ${format}, folder: ${folder}, customNamePrefix: ${customNamePrefix}, autoStart: ${autoStart}, strictPlaylistMode: ${strictPlaylistMode}`);
     let meTubeUrl = await getMeTubeUrl();
     if (!meTubeUrl) {
       await showError('MeTube instance url not configured. Go to about:addons to configure.');
@@ -151,7 +152,8 @@ async function sendToMeTube(itemUrl, quality, format, folder, customNamePrefix, 
           "format": format,
           "folder": folder,
           "custom_name_prefix": customNamePrefix,
-          "auto_start": autoStart
+          "auto_start": autoStart,
+          "playlist_strict_mode": strictPlaylistMode
         })
       });
 
@@ -207,7 +209,7 @@ function triggerSendWithLoading(url) {
 
     const options = await getDefaultSendOptions();
     await sendToMeTube(url, options.quality, options.format, options.folder,
-                       options.customNamePrefix, options.autoStart);
+                       options.customNamePrefix, options.autoStart, options.strictPlaylistMode);
   }, 100);
 }
 
@@ -231,7 +233,8 @@ browser.runtime.onMessage.addListener(async (message) => {
     let folder = message.folder || await getDefaultFolder();
     let customNamePrefix = message.customNamePrefix || await getDefaultCustomNamePrefix();
     let autoStart = message.autoStart || await getDefaultAutoStart();
-    await sendToMeTube(url, quality, format, folder, customNamePrefix, autoStart);
+    let strictPlaylistMode = message.strictPlaylistMode || await getDefaultStrictPlaylistMode();
+    await sendToMeTube(url, quality, format, folder, customNamePrefix, autoStart, strictPlaylistMode);
   } else if (message.command === "settingsUpdated") {
     await updateBrowserActionPopup();
   }

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -28,6 +28,11 @@ async function getDefaultAutoStart() {
   return item.defaultAutoStart ?? true;
 }
 
+async function getDefaultStrictPlaylistMode() {
+  let item = await browser.storage.sync.get("strictPlaylistMode");
+  return item.strictPlaylistMode ?? false;
+}
+
 async function requestPermissionsForUrl(url, useCookieAuth) {
   try {
     const permissionRequest = {};

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -70,6 +70,10 @@
           <label for="oneClickMode">One-click mode - automatically send the current page to MeTube instance when you click the extension icon (no popup, default values)</label>
         </div>
         <div class="field">
+          <input type="checkbox" id="strictPlaylistMode" />
+          <label for="strictPlaylistMode">Strict Playlist Mode - only download playlists when URL explicitly points to a playlist</label>
+        </div>
+        <div class="field">
           <input type="checkbox" id="useCookieAuth" />
           <label for="useCookieAuth">Send cookies for authentication (required for SSO/reverse proxy auth)</label>
           <div id="ssoWarning" class="hidden" style="margin-top: 0.5rem; padding: 0.5rem; background-color: #fff3cd; border: 1px solid #ffc107; border-radius: 4px;">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -49,6 +49,7 @@ async function saveOptions(e) {
     defaultCustomNamePrefix: document.querySelector("#defaultCustomNamePrefix").value,
     defaultAutoStart: document.querySelector("#defaultAutoStart").checked,
     oneClickMode: document.querySelector("#oneClickMode").checked,
+    strictPlaylistMode: document.querySelector("#strictPlaylistMode").checked,
   });
 
   browser.menus.update("send-to-metube", {
@@ -126,6 +127,11 @@ function restoreOptions() {
   let getOneClickMode = browser.storage.sync.get("oneClickMode");
   getOneClickMode.then(function(result) {
     document.querySelector("#oneClickMode").checked = result.oneClickMode || false;
+  }, onError);
+
+  let getStrictPlaylistMode = browser.storage.sync.get("strictPlaylistMode");
+  getStrictPlaylistMode.then(function(result) {
+    document.querySelector("#strictPlaylistMode").checked = result.strictPlaylistMode || false;
   }, onError);
 
   let getUseCookieAuth = browser.storage.sync.get("useCookieAuth");

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -56,6 +56,10 @@
         <input type="checkbox" id="autoStart" />
         <label for="autoStart">Auto Start</label>
       </div>
+      <div class="row">
+        <input type="checkbox" id="strictPlaylistMode" />
+        <label for="strictPlaylistMode">Strict Playlist Mode</label>
+      </div>
       <div id="buttons-row">
         <button id="sendToMeTube" class="send-to-metube">
           <span id="loadingSpinner" class="spinner hidden"></span>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -30,7 +30,8 @@ document.getElementById("sendToMeTube").addEventListener("click", async function
   let folder = document.getElementById('folder').value;
   let customNamePrefix = document.getElementById('customNamePrefix').value;
   let autoStart = document.getElementById('autoStart').checked;
-  await browser.runtime.sendMessage({ command: 'sendToMeTube', quality: quality, format: format, url: url, folder: folder, customNamePrefix: customNamePrefix, autoStart: autoStart });
+  let strictPlaylistMode = document.getElementById('strictPlaylistMode').checked;
+  await browser.runtime.sendMessage({ command: 'sendToMeTube', quality: quality, format: format, url: url, folder: folder, customNamePrefix: customNamePrefix, autoStart: autoStart, strictPlaylistMode: strictPlaylistMode });
 });
 
 function showError(errorMessage) {
@@ -101,6 +102,7 @@ addEventListener('DOMContentLoaded', async (event) => {
   document.getElementById('folder').value = await getDefaultFolder() || "";
   document.getElementById('customNamePrefix').value = await getDefaultCustomNamePrefix() || "";
   document.getElementById('autoStart').checked = await getDefaultAutoStart() ?? true;
+  document.getElementById('strictPlaylistMode').checked = await getDefaultStrictPlaylistMode() ?? false;
 
   //await fetchHistory();
 });


### PR DESCRIPTION
Adds support for MeTube's "Strict Playlist Mode" option, allowing users to control whether playlist URLs should be treated as playlists or single videos. Without this option it tries to download all videos of your YouTube Mixes when you only want to save the one specific video that's currently playing.

- Adds a "Strict Playlist Mode" checkbox in extension settings (options page)
- Adds a "Strict Playlist Mode" checkbox in the popup for per-download control
- Passes the `playlist_strict_mode` parameter to MeTube
- Is disabled by default